### PR TITLE
Fix: std.mem.tokenize() usage for Zig 0.9

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -65,7 +65,8 @@ pub fn main() !void {
 
         // split,collect argv into args = [][]
         var args = ArrayList([]const u8).init(allocator);
-        var tokens = std.mem.tokenize(line, " ");
+        // var tokens = std.mem.tokenize(line, " ");
+        var tokens = std.mem.tokenize(u8, line, " ");
         while (tokens.next()) |token| {
             try args.append(token);
         }

--- a/src/main.zig
+++ b/src/main.zig
@@ -65,7 +65,6 @@ pub fn main() !void {
 
         // split,collect argv into args = [][]
         var args = ArrayList([]const u8).init(allocator);
-        // var tokens = std.mem.tokenize(line, " ");
         var tokens = std.mem.tokenize(u8, line, " ");
         while (tokens.next()) |token| {
             try args.append(token);


### PR DESCRIPTION
This commit updates the usage of std.mem.tokenize() to work with the Zig 0.9 stdlib API. That allows conch to compile under Zig 0.9.

Note that this breaks compatibility with older stdlib versions. I'm expecting the `beta` test to fail for this reason.